### PR TITLE
Make label and color customizable

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,18 @@ You need to add counter in README.md file in your profile repository via Markdow
 
 ### Customization
 
+#### Label
+
+You could overwrite default `Profile views` text with your own label.
+
+![](https://img.shields.io/static/v1?label=PROFILE+VIEWS&message=1234567890&color=007ec6)
+
+```markdown
+![](https://komarev.com/ghpvc/?username=your-github-username&label=PROFILE+VIEWS)
+```
+
+> **NOTE**: Replace whitespace with `+` character.
+
 #### Styles
 
 The following styles are available (`flat` is the default):

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ You need to add counter in README.md file in your profile repository via Markdow
 
 #### Color
 
-You could pick any HEX color or pick from a predefined set of named colors (`blue` is the default).
+You could use any valid HEX color or pick from a predefined set of named colors (`blue` is the default).
 
 | color | demo |
 | ----- | ---- |

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ You need to add counter in README.md file in your profile repository via Markdow
 
 #### Color
 
-You could use any valid HEX color or pick from a predefined set of named colors (`blue` is the default).
+You can use any valid HEX color or pick from a predefined set of named colors (`blue` is the default).
 
 | color | demo |
 | ----- | ---- |
@@ -85,7 +85,7 @@ The following styles are available (`flat` is the default).
 
 #### Label
 
-You could overwrite default `Profile views` text with your own label.
+You can overwrite default `Profile views` text with your own label.
 
 ![](https://img.shields.io/static/v1?label=PROFILE+VIEWS&message=1234567890&color=007ec6)
 

--- a/README.md
+++ b/README.md
@@ -38,21 +38,40 @@ You need to add counter in README.md file in your profile repository via Markdow
 
 ### Customization
 
-#### Label
+#### Color
 
-You could overwrite default `Profile views` text with your own label.
+You could pick any HEX color or pick from a predefined set of named colors (`blue` is the default).
 
-![](https://img.shields.io/static/v1?label=PROFILE+VIEWS&message=1234567890&color=007ec6)
+| color | demo |
+| ----- | ---- |
+| brightgreen` | ![](https://img.shields.io/static/v1?label=Profile+views&message=1234567890&color=44cc11) |
+| green | ![](https://img.shields.io/static/v1?label=Profile+views&message=1234567890&color=97ca00) |
+| yellow | ![](https://img.shields.io/static/v1?label=Profile+views&message=1234567890&color=dfb317) |
+| yellowgreen | ![](https://img.shields.io/static/v1?label=Profile+views&message=1234567890&color=a4a61d) |
+| orange | ![](https://img.shields.io/static/v1?label=Profile+views&message=1234567890&color=fe7d37) |
+| red | ![](https://img.shields.io/static/v1?label=Profile+views&message=1234567890&color=e05d44) |
+| blue | ![](https://img.shields.io/static/v1?label=Profile+views&message=1234567890&color=007ec6) |
+| grey | ![](https://img.shields.io/static/v1?label=Profile+views&message=1234567890&color=555555) |
+| lightgray | ![](https://img.shields.io/static/v1?label=Profile+views&message=1234567890&color=9f9f9f) |
+| ff69b4 | ![](https://img.shields.io/static/v1?label=Profile+views&message=1234567890&color=ff69b4) |
+
+**Named color**
 
 ```markdown
-![](https://komarev.com/ghpvc/?username=your-github-username&label=PROFILE+VIEWS)
+![](https://komarev.com/ghpvc/?username=your-github-username&color=green)
 ```
 
-> **NOTE**: Replace whitespace with `+` character.
+**Hex color**
+
+```markdown
+![](https://komarev.com/ghpvc/?username=your-github-username&color=dc143c)
+```
+
+> **NOTE**: HEX colors should be used without `#` symbol prefix.
 
 #### Styles
 
-The following styles are available (`flat` is the default):
+The following styles are available (`flat` is the default).
 
 | style | demo |
 | ----- | ---- |
@@ -64,7 +83,17 @@ The following styles are available (`flat` is the default):
 ![](https://komarev.com/ghpvc/?username=your-github-username&style=flat-square)
 ```
 
-For example
+#### Label
+
+You could overwrite default `Profile views` text with your own label.
+
+![](https://img.shields.io/static/v1?label=PROFILE+VIEWS&message=1234567890&color=007ec6)
+
+```markdown
+![](https://komarev.com/ghpvc/?username=your-github-username&label=PROFILE+VIEWS)
+```
+
+> **NOTE**: Replace whitespace with `+` character in multi-word labels.
 
 ## Is it safe to place tracking image? 
 

--- a/README.md
+++ b/README.md
@@ -44,16 +44,16 @@ You could pick any HEX color or pick from a predefined set of named colors (`blu
 
 | color | demo |
 | ----- | ---- |
-| brightgreen` | ![](https://img.shields.io/static/v1?label=Profile+views&message=1234567890&color=44cc11) |
-| green | ![](https://img.shields.io/static/v1?label=Profile+views&message=1234567890&color=97ca00) |
-| yellow | ![](https://img.shields.io/static/v1?label=Profile+views&message=1234567890&color=dfb317) |
-| yellowgreen | ![](https://img.shields.io/static/v1?label=Profile+views&message=1234567890&color=a4a61d) |
-| orange | ![](https://img.shields.io/static/v1?label=Profile+views&message=1234567890&color=fe7d37) |
-| red | ![](https://img.shields.io/static/v1?label=Profile+views&message=1234567890&color=e05d44) |
-| blue | ![](https://img.shields.io/static/v1?label=Profile+views&message=1234567890&color=007ec6) |
-| grey | ![](https://img.shields.io/static/v1?label=Profile+views&message=1234567890&color=555555) |
-| lightgray | ![](https://img.shields.io/static/v1?label=Profile+views&message=1234567890&color=9f9f9f) |
-| ff69b4 | ![](https://img.shields.io/static/v1?label=Profile+views&message=1234567890&color=ff69b4) |
+| `brightgreen` | ![](https://img.shields.io/static/v1?label=Profile+views&message=1234567890&color=44cc11) |
+| `green` | ![](https://img.shields.io/static/v1?label=Profile+views&message=1234567890&color=97ca00) |
+| `yellow` | ![](https://img.shields.io/static/v1?label=Profile+views&message=1234567890&color=dfb317) |
+| `yellowgreen` | ![](https://img.shields.io/static/v1?label=Profile+views&message=1234567890&color=a4a61d) |
+| `orange` | ![](https://img.shields.io/static/v1?label=Profile+views&message=1234567890&color=fe7d37) |
+| `red` | ![](https://img.shields.io/static/v1?label=Profile+views&message=1234567890&color=e05d44) |
+| `blue` | ![](https://img.shields.io/static/v1?label=Profile+views&message=1234567890&color=007ec6) |
+| `grey` | ![](https://img.shields.io/static/v1?label=Profile+views&message=1234567890&color=555555) |
+| `lightgray` | ![](https://img.shields.io/static/v1?label=Profile+views&message=1234567890&color=9f9f9f) |
+| `ff69b4` | ![](https://img.shields.io/static/v1?label=Profile+views&message=1234567890&color=ff69b4) |
 
 **Named color**
 

--- a/public/file-repository.php
+++ b/public/file-repository.php
@@ -39,7 +39,7 @@ try {
     }
 
     $badgeLabel = $_GET['label'] ?? 'Profile views';
-    $badgeMessageBackgroundFill = $_GET['color'] ?? '007ec6';
+    $badgeMessageBackgroundFill = $_GET['color'] ?? 'blue';
     $badgeStyle = $_GET['style'] ?? 'flat';
     if (!in_array($badgeStyle, ['flat', 'flat-square', 'plastic'])) {
         $badgeStyle = 'flat';

--- a/public/file-repository.php
+++ b/public/file-repository.php
@@ -38,6 +38,8 @@ try {
         $storagePath = $_ENV['FILE_STORAGE_PATH'];
     }
 
+    $badgeLabel = $_GET['label'] ?? 'Profile views';
+    $badgeMessageBackgroundFill = $_GET['color'] ?? '007ec6';
     $badgeStyle = $_GET['style'] ?? 'flat';
     if (!in_array($badgeStyle, ['flat', 'flat-square', 'plastic'])) {
         $badgeStyle = 'flat';
@@ -46,7 +48,7 @@ try {
     $username = trim($username);
 
     if ($username === '') {
-        echo $badgeImageRenderer->renderBadgeWithError($badgeStyle, 'Invalid query parameter: username');
+        echo $badgeImageRenderer->renderBadgeWithError($badgeLabel, 'Invalid query parameter: username', $badgeStyle);
         exit;
     }
 
@@ -65,9 +67,9 @@ try {
 
     $count = $counterRepository->getViewsCountByUsername($username);
 
-    echo $badgeImageRenderer->renderBadgeWithCount($badgeStyle, $count);
+    echo $badgeImageRenderer->renderBadgeWithCount($badgeLabel, $count, $badgeMessageBackgroundFill, $badgeStyle);
     exit;
 } catch (Exception $exception) {
-    echo $badgeImageRenderer->renderBadgeWithError($badgeStyle, $exception->getMessage());
+    echo $badgeImageRenderer->renderBadgeWithError($badgeLabel, $exception->getMessage(), $badgeStyle);
     exit;
 }

--- a/public/pdo-repository.php
+++ b/public/pdo-repository.php
@@ -43,7 +43,7 @@ try {
     $httpUserAgent = $_SERVER['HTTP_USER_AGENT'];
 
     $badgeLabel = $_GET['label'] ?? 'Profile views';
-    $badgeMessageBackgroundFill = $_GET['color'] ?? '007ec6';
+    $badgeMessageBackgroundFill = $_GET['color'] ?? 'blue';
     $badgeStyle = $_GET['style'] ?? 'flat';
     if (!in_array($badgeStyle, ['flat', 'flat-square', 'plastic'])) {
         $badgeStyle = 'flat';

--- a/public/pdo-repository.php
+++ b/public/pdo-repository.php
@@ -42,6 +42,8 @@ try {
 
     $httpUserAgent = $_SERVER['HTTP_USER_AGENT'];
 
+    $badgeLabel = $_GET['label'] ?? 'Profile views';
+    $badgeMessageBackgroundFill = $_GET['color'] ?? '007ec6';
     $badgeStyle = $_GET['style'] ?? 'flat';
     if (!in_array($badgeStyle, ['flat', 'flat-square', 'plastic'])) {
         $badgeStyle = 'flat';
@@ -50,7 +52,7 @@ try {
     $username = trim($username);
 
     if ($username === '') {
-        echo $badgeImageRenderer->renderBadgeWithError($badgeStyle, 'Invalid query parameter: username');
+        echo $badgeImageRenderer->renderBadgeWithError($badgeLabel, 'Invalid query parameter: username', $badgeStyle);
         exit;
     }
 
@@ -78,12 +80,12 @@ try {
 
     $count = $counterRepository->getViewsCountByUsername($username);
 
-    echo $badgeImageRenderer->renderBadgeWithCount($badgeStyle, $count);
+    echo $badgeImageRenderer->renderBadgeWithCount($badgeLabel, $count, $badgeMessageBackgroundFill, $badgeStyle);
     exit;
 } catch (InvalidPathException $exception) {
-    echo $badgeImageRenderer->renderBadgeWithError($badgeStyle, 'Application environment file is missing');
+    echo $badgeImageRenderer->renderBadgeWithError($badgeLabel, 'Application environment file is missing', $badgeStyle);
     exit;
 } catch (Exception $exception) {
-    echo $badgeImageRenderer->renderBadgeWithError($badgeStyle, $exception->getMessage());
+    echo $badgeImageRenderer->renderBadgeWithError($badgeLabel, $exception->getMessage(), $badgeStyle);
     exit;
 }

--- a/src/BadgeImageRendererService.php
+++ b/src/BadgeImageRendererService.php
@@ -40,7 +40,7 @@ final class BadgeImageRendererService
 
     public function renderBadgeWithError(string $label, string $message, string $badgeStyle): string
     {
-        $messageBackgroundFill = 'e05d44';
+        $messageBackgroundFill = 'red';
 
         return $this->renderBadge($label, $message, $messageBackgroundFill, $badgeStyle);
     }

--- a/src/BadgeImageRendererService.php
+++ b/src/BadgeImageRendererService.php
@@ -24,32 +24,34 @@ final class BadgeImageRendererService
 
     public function __construct()
     {
-        $this->poser = new Poser([new SvgRender(), new SvgFlatRender(), new SvgFlatSquareRender()]);
+        $this->poser = new Poser([
+            new SvgRender(),
+            new SvgFlatRender(),
+            new SvgFlatSquareRender(),
+        ]);
     }
 
-    public function renderBadgeWithCount($badgeStyle, int $count): string
+    public function renderBadgeWithCount(string $label, int $count, string $messageBackgroundFill, string $badgeStyle): string
     {
         $message = (string) $count;
 
-        $messageBackgroundFill = '007ec6';
-
-        return $this->renderBadge($badgeStyle, $message, $messageBackgroundFill);
+        return $this->renderBadge($label, $message, $messageBackgroundFill, $badgeStyle);
     }
 
-    public function renderBadgeWithError($badgeStyle, string $message): string
+    public function renderBadgeWithError(string $label, string $message, string $badgeStyle): string
     {
         $messageBackgroundFill = 'e05d44';
 
-        return $this->renderBadge($badgeStyle, $message, $messageBackgroundFill);
-    }
-
-    private function renderBadge($badgeStyle, string $message, string $messageBackgroundFill): string
-    {
-        return (string) $this->poser->generate('Profile views', $message, $messageBackgroundFill, $badgeStyle);
+        return $this->renderBadge($label, $message, $messageBackgroundFill, $badgeStyle);
     }
 
     public function renderPixel(): string
     {
         return '<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1"/>';
+    }
+
+    private function renderBadge(string $label, string $message, string $messageBackgroundFill, string $badgeStyle): string
+    {
+        return (string) $this->poser->generate($label, $message, $messageBackgroundFill, $badgeStyle);
     }
 }


### PR DESCRIPTION
This PR adds badge label and message background color customization.

#### Color

You can use any valid HEX color or pick from a predefined set of named colors (`blue` is the default).

| color | demo |
| ----- | ---- |
| `brightgreen` | ![](https://img.shields.io/static/v1?label=Profile+views&message=1234567890&color=44cc11) |
| `green` | ![](https://img.shields.io/static/v1?label=Profile+views&message=1234567890&color=97ca00) |
| `yellow` | ![](https://img.shields.io/static/v1?label=Profile+views&message=1234567890&color=dfb317) |
| `yellowgreen` | ![](https://img.shields.io/static/v1?label=Profile+views&message=1234567890&color=a4a61d) |
| `orange` | ![](https://img.shields.io/static/v1?label=Profile+views&message=1234567890&color=fe7d37) |
| `red` | ![](https://img.shields.io/static/v1?label=Profile+views&message=1234567890&color=e05d44) |
| `blue` | ![](https://img.shields.io/static/v1?label=Profile+views&message=1234567890&color=007ec6) |
| `grey` | ![](https://img.shields.io/static/v1?label=Profile+views&message=1234567890&color=555555) |
| `lightgray` | ![](https://img.shields.io/static/v1?label=Profile+views&message=1234567890&color=9f9f9f) |
| `ff69b4` | ![](https://img.shields.io/static/v1?label=Profile+views&message=1234567890&color=ff69b4) |

**Named color**

```markdown
![](https://komarev.com/ghpvc/?username=your-github-username&color=green)
```

**Hex color**

```markdown
![](https://komarev.com/ghpvc/?username=your-github-username&color=dc143c)
```

> **NOTE**: HEX colors should be used without `#` symbol prefix.

#### Label

You can overwrite default `Profile views` text with your own label.

![](https://img.shields.io/static/v1?label=PROFILE+VIEWS&message=1234567890&color=007ec6)

```markdown
![](https://komarev.com/ghpvc/?username=your-github-username&label=PROFILE+VIEWS)
```

> **NOTE**: Replace whitespace with `+` character in multi-word labels.