### PR TITLE
Fix undefined user agent warning

### DIFF
--- a/public/file-repository.php
+++ b/public/file-repository.php
@@ -30,7 +30,7 @@ try {
     $dotEnv = Dotenv::createImmutable($basePath);
     $dotEnv->safeLoad();
 
-    $httpUserAgent = $_SERVER['HTTP_USER_AGENT'];
+    $httpUserAgent = $_SERVER['HTTP_USER_AGENT'] ?? '';
 
     if (!isset($_ENV['FILE_STORAGE_PATH']) || $_ENV['FILE_STORAGE_PATH'] === null) {
         $storagePath = $basePath . '/storage';

--- a/public/pdo-repository.php
+++ b/public/pdo-repository.php
@@ -40,7 +40,7 @@ try {
         'DB_NAME',
     ]);
 
-    $httpUserAgent = $_SERVER['HTTP_USER_AGENT'];
+    $httpUserAgent = $_SERVER['HTTP_USER_AGENT'] ?? '';
 
     $badgeLabel = $_GET['label'] ?? 'Profile views';
     $badgeMessageBackgroundFill = $_GET['color'] ?? 'blue';


### PR DESCRIPTION
This PR fixes fatal error when sneaky guys try to cheat:
> PHP Notice:  Undefined index: HTTP_USER_AGENT
> PHP Fatal error:  Uncaught TypeError: strpos() expects parameter 1 to be string, null given