### PR TITLE
Add continuous integration with github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: continuous integration
+on:
+  pull_request:
+  push: { branches: master }
+jobs:
+  php_test:
+    name: PHP Test
+    runs-on: ${{ matrix.operating-system }}
+    strategy:
+      matrix:
+        operating-system: ['ubuntu-latest', 'windows-latest', 'macos-latest']
+        php-versions: ['7.4', '8.0', '8.1']
+    steps:
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ matrix.php-versions }}
+        extensions: mbstring, intl
+        ini-values: post_max_size=256M, max_execution_time=180
+        coverage: xdebug
+        tools: php-cs-fixer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,3 +19,13 @@ jobs:
         ini-values: post_max_size=256M, max_execution_time=180
         coverage: xdebug
         tools: php-cs-fixer
+  docker_test:
+    name: Build Docker Image Test
+    runs-on: ubuntu-latest
+    env:
+      COMPOSE_FILE: docker-compose.yaml
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Build docker images
+      run: docker-compose build


### PR DESCRIPTION
Doing test projects with various operating systems and different PHP versions, Also added Docker Test

## Setup PHP test

```
 php_test:
    name: PHP Test
    runs-on: ${{ matrix.operating-system }}
    strategy:
      matrix:
        operating-system: ['ubuntu-latest', 'windows-latest', 'macos-latest']
        php-versions: ['7.4', '8.0', '8.1']
    steps:
    - name: Setup PHP
      uses: shivammathur/setup-php@v2
      with:
        php-version: ${{ matrix.php-versions }}
        extensions: mbstring, intl
        ini-values: post_max_size=256M, max_execution_time=180
        coverage: xdebug
        tools: php-cs-fixer
```

The PHP version used is as follows:

```
['7.4', '8.0', '8.1']
```

The operating system used is as follows:

```
['ubuntu-latest', 'windows-latest', 'macos-latest']
```

PHP extensions :

```
extensions: mbstring, intl
```

## Setup Docker Test

```
  docker_test:
    name: Build Docker Image Test
    runs-on: ubuntu-latest
    env:
      COMPOSE_FILE: docker-compose.yaml
    steps:
    - name: Checkout code
      uses: actions/checkout@v2
    - name: Build docker images
      run: docker-compose build
```

Run Docker Build

```
  - name: Build docker images
      run: docker-compose build
```

## DEMO 

View full results:

https://github.com/rizkytegar/github-profile-views-counter/actions/runs/2607304106

Take a look at the PHP test example:

https://github.com/rizkytegar/github-profile-views-counter/runs/7173221851?check_suite_focus=true

Take a look at the Docker test example:

https://github.com/rizkytegar/github-profile-views-counter/runs/7173221594?check_suite_focus=true